### PR TITLE
Remove google font import as it was redundant since local font is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,6 @@ export default config;
 <summary><code>globals.css</code></summary>
 
 ```css
-@import url("https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap");
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
Since we are using local fonts this import is not required anymore.