### PR TITLE
Persisting form state after the startup is submitted on /startup/create page

### DIFF
--- a/components/StartupForm.tsx
+++ b/components/StartupForm.tsx
@@ -19,15 +19,17 @@ const StartupForm = () => {
   const router = useRouter();
 
   const handleFormSubmit = async (prevState: any, formData: FormData) => {
-    try {
-      const formValues = {
-        title: formData.get("title") as string,
-        description: formData.get("description") as string,
-        category: formData.get("category") as string,
-        link: formData.get("link") as string,
-        pitch,
-      };
 
+    // Storing the formdata in an object to persist in the useActionState().
+    const formValues = {
+      title: formData.get("title") as string,
+      description: formData.get("description") as string,
+      category: formData.get("category") as string,
+      link: formData.get("link") as string,
+      pitch,
+    };
+
+    try {
       await formSchema.parseAsync(formValues);
 
       const result = await createPitch(prevState, formData, pitch);
@@ -54,7 +56,7 @@ const StartupForm = () => {
           variant: "destructive",
         });
 
-        return { ...prevState, error: "Validation failed", status: "ERROR" };
+        return { ...prevState, error: "Validation failed", status: "ERROR", data: formValues };
       }
 
       toast({
@@ -67,6 +69,7 @@ const StartupForm = () => {
         ...prevState,
         error: "An unexpected error has occurred",
         status: "ERROR",
+        data: formValues
       };
     }
   };
@@ -74,6 +77,7 @@ const StartupForm = () => {
   const [state, formAction, isPending] = useActionState(handleFormSubmit, {
     error: "",
     status: "INITIAL",
+    data: {}
   });
 
   return (
@@ -88,6 +92,7 @@ const StartupForm = () => {
           className="startup-form_input"
           required
           placeholder="Startup Title"
+          defaultValue={state?.data?.title}
         />
 
         {errors.title && <p className="startup-form_error">{errors.title}</p>}
@@ -103,6 +108,7 @@ const StartupForm = () => {
           className="startup-form_textarea"
           required
           placeholder="Startup Description"
+          defaultValue={state?.data?.description}
         />
 
         {errors.description && (
@@ -120,6 +126,7 @@ const StartupForm = () => {
           className="startup-form_input"
           required
           placeholder="Startup Category (Tech, Health, Education...)"
+          defaultValue={state?.data?.category}
         />
 
         {errors.category && (
@@ -137,6 +144,7 @@ const StartupForm = () => {
           className="startup-form_input"
           required
           placeholder="Startup Image URL"
+          defaultValue={state?.data?.link}
         />
 
         {errors.link && <p className="startup-form_error">{errors.link}</p>}


### PR DESCRIPTION
### Description:

This change updates the /startup/create page to persist form values after the form is submitted.

### How:
Added a new field called data, in the default state of useActionState() hook. Once the user submits the form, the current form values are returned back to persist in the state.

Form elements like inputs, textarea is updated to consume defaultValue property, which points to the state.data

### Screenshots:

Form values are not erased and persisted even after user clicks on submit button in case of error.
![Screenshot 2025-02-11 at 8 45 32 PM](https://github.com/user-attachments/assets/f1cb7158-56f4-42bb-8a2a-32788b9cd816)

When user updates the inputs, previous error messages are removed if user corrected data for an input field.
![Screenshot 2025-02-11 at 8 45 44 PM](https://github.com/user-attachments/assets/6b7b73b1-e07d-454c-80e4-23d300a9f216)
